### PR TITLE
fix: Enhance cookie detection for Firefox in Flatpak

### DIFF
--- a/yt_dlp/cookies.py
+++ b/yt_dlp/cookies.py
@@ -215,6 +215,11 @@ def _firefox_browser_dirs():
             # New installations of FF147+ respect the XDG base directory specification
             # Ref: https://bugzilla.mozilla.org/show_bug.cgi?id=259356
             os.path.join(_config_home(), 'mozilla/firefox'),
+            # _config_home() on yt-dlp running within Flatpak returns the Flatpak app's config directory
+            # This allows for detecting installations of FF147+'s config from within a Flatpak app
+            # Of course, if XDG_CONFIG_HOME is different than ~/.config on the host machine, this path would
+            # be incorrect. However, more time than not this will be correct
+            '~/.config/mozilla/firefox',
             # Existing FF version<=146 installations
             '~/.mozilla/firefox',
             # Flatpak XDG: https://docs.flatpak.org/en/latest/conventions.html#xdg-base-directories


### PR DESCRIPTION
<!--
    **IMPORTANT**: PRs without the template will be CLOSED
    
    Due to the high volume of pull requests, it may be a while before your PR is reviewed.
    Please try to keep your pull request focused on a single bugfix or new feature.
    Pull requests with a vast scope and/or very large diff will take much longer to review.
    It is recommended for new contributors to stick to smaller pull requests, so you can receive much more immediate feedback as you familiarize yourself with the codebase.

    PLEASE AVOID FORCE-PUSHING after opening a PR, as it makes reviewing more difficult.
-->

### Description of your *pull request* and other information

Add support for detecting system Firefox config in Flatpak installations where `_config_home()` returns the Flatpak app's config folder and not the user's.


<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--
    # PLEASE FOLLOW THE GUIDE BELOW

    - You will be asked some questions, please read them **carefully** and answer honestly
    - Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
    - Use *Preview* tab to see what your *pull request* will actually look like
-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check those that apply and remove the others:
- [x] I am the original author of the code in this PR, and I am willing to release it under [Unlicense](http://unlicense.org/)
- [x] I have read the [policy against AI/LLM contributions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#automated-contributions-ai--llm-policy) and understand I may be blocked from the repository if it is violated

### What is the purpose of your *pull request*? Check those that apply and remove the others:
- [x] Core bug fix/improvement

</details>
